### PR TITLE
Organism variable

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,9 @@ class Config:
         self.tile_width = 5
         self.tile_height = 5
 
+        self.danger_min_life = 15
+        self.danger_max_life = 15
+
         self.population_size = 50
 
         self.organism_min_life = 60

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,7 @@ def main():
         screen.fill((255, 255, 255))
 
         world.draw(config, screen)
-        # world.spread(config)
+        world.spread(config)
         population.draw(config, screen)
         population.update(config)
         # drawing everything

--- a/src/main.py
+++ b/src/main.py
@@ -23,7 +23,7 @@ def main():
         world.draw(config, screen)
         world.spread(config)
         population.draw(config, screen)
-        population.update(config)
+        population.update(config, world.grid)
         # drawing everything
 
         screen_update()

--- a/src/organisms/organism.py
+++ b/src/organisms/organism.py
@@ -28,12 +28,12 @@ class Organism:
         self.position.x += direction[0]
         self.position.y += direction[1]
 
-        if self.position.x > config.row_length - 1: # stop organsims from exiting the screen from left/rigth
+        if self.position.x >= config.row_length: # stop organsims from exiting the screen from left/rigth
             self.position.x = config.row_length - 1
         elif self.position.x < 0:
             self.position.x = 0
         
-        if self.position.y > config.column_length - 1: # stop organsims from exiting the screen from top/bottom
+        if self.position.y >= config.column_length: # stop organsims from exiting the screen from top/bottom
             self.position.y = config.column_length - 1
         elif self.position.y < 0:
             self.position.y = 0
@@ -43,8 +43,10 @@ class Organism:
         if self.lifetime <= 0:
             self.alive = False
     
-    def update(self, config):
+    def update(self, config, grid):
+        grid[self.position.y][self.position.x].has_organism = False
         self.move(self.directions[self.nn.calc_greatest([randint(0, 10)])], config)
+        grid[self.position.y][self.position.x].has_organism = True
         # self.update_lifetime()
 
 

--- a/src/organisms/population.py
+++ b/src/organisms/population.py
@@ -3,16 +3,17 @@ from random import randint
 
 class Population:
     def __init__(self, config):
-        self.organisms = [Organism(config, randint(0, config.row_length), randint(0, config.column_length)) for i in range(config.population_size)]
+        self.organisms = [Organism(config, randint(0, config.row_length - 1), randint(0, config.column_length - 1)) for i in range(config.population_size)]
     
     def draw(self, config, display):
         for organism in self.organisms:
             organism.draw(config, display)
     
-    def update(self, config):
+    def update(self, config, grid):
         for organism in self.organisms:
-            organism.update(config)
+            organism.update(config, grid)
             if not organism.alive:
+                grid[organism.position.y][organism.position.x].has_organism = False
                 self.organisms.remove(organism)
     
 

--- a/src/world/environment.py
+++ b/src/world/environment.py
@@ -13,17 +13,22 @@ class Food(Tile):
 class Danger(Tile):
   def __init__(self, config, x_pos, y_pos):
     Tile.__init__(self, config, x_pos, y_pos, "danger")
+    self.lifetime = randint(config.danger_min_life, config.danger_max_life)
 
   def draw(self, config, display):
     pygame.draw.rect(display, (255, 0, 0), (self.position.x * config.tile_width, self.position.y * config.tile_width, config.tile_width, config.tile_width))
   
   
   def spread(self, world, config):
-    for i in range(self.position.y - 1, self.position.y + 2):
-      for j in range(self.position.x - 1, self.position.x + 2):
-        if i >= 0 and i < config.column_length and j >= 0 and j < config.row_length:
-          if randint(0, 100) == 0:
-            world[i][j] = Danger(config, j, i)
+    if self.lifetime > 0:
+      for y in range(self.position.y - 1, self.position.y + 2):
+        for x in range(self.position.x - 1, self.position.x + 2):
+          if y >= 0 and y < config.column_length and x >= 0 and x < config.row_length:
+            if randint(0, 100) == 0:
+              world[y][x] = Danger(config, x, y)
+      self.lifetime -= 1
+    else:
+      world[self.position.y][self.position.x] = Empty(config, self.position.x, self.position.y)
 
 
 class Empty(Tile):

--- a/src/world/tile.py
+++ b/src/world/tile.py
@@ -9,6 +9,7 @@ class Tile:
         self.height = config.tile_height
         self.position = Position(x_pos, y_pos)
         self.content = content
+        self.has_organism = False
     
     def draw(self, config, display):
         pass


### PR DESCRIPTION
- all changes from danger cycles branch
- new variable for regular tile class: has_organism, False by default

- organism.py: 
- changed the "in bounds" check from move function to look nicer (>= is better than > value - 1 in my opinion)
- before moving sets the has_organism variable of the current tile to false
- after moving sets the has_organism variable of the new tile to true
- because of that, update function now requires world parameter

- population.py:
-  changed upper caps of spawn coordinates to be row/column_length - 1 as without the - 1 it would be out of bounds
- if an organism dies, after it is removed from the populations list, the has_organism of the tile it was on is set to False
- added the world argument to update calls in population and main (named grid, maybe change to world for uniformity)

- Issue with new variable:
- if we allow for multiple organism on the same tile, if one of them decides to stay and after that another one moves away or dies, the variable would be set to false even though organism 1 would still be on that tile, maybe have them not move onto a field where there already is an organism
- then we would have to change spawning to search for a tile where there is no organism, which could take very long for a big number of organisms, we would also probably need a list with the coordinates of all the currently spawned organism for quick access to the coordinates to see if they are occupied...