### PR TITLE
Fix organism cramming

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -18,7 +18,7 @@ class Config:
         self.food_max_spread = 100
         self.food_spread_chance = 5 # final chance wile be 1 / spread_chance
 
-        self.population_size = 1000
+        self.population_size = 500
 
         self.organism_min_life = 60
         self.organism_max_life = 100

--- a/src/organisms/organism.py
+++ b/src/organisms/organism.py
@@ -26,34 +26,26 @@ class Organism:
                         (0, 1),
                         (1, 1)] # used as inputs for the move function, one element for moving to one of the adjacent tiles
 
-    def eat(self, config, grid):
-        grid[self.position.y][self.position.x] = Empty(config, self.position.x, self.position.y)
+    def eat(self, config, world):
+        world[self.position.y][self.position.x] = Empty(config, self.position.x, self.position.y)
 
-    def move(self, direction, config):
-        self.position.x += direction[0]
-        self.position.y += direction[1]
-
-        if self.position.x >= config.row_length: # stop organsims from exiting the screen from left/rigth
-            self.position.x = config.row_length - 1
-        elif self.position.x < 0:
-            self.position.x = 0
-        
-        if self.position.y >= config.column_length: # stop organsims from exiting the screen from top/bottom
-            self.position.y = config.column_length - 1
-        elif self.position.y < 0:
-            self.position.y = 0
+    def move(self, config, direction, world):
+        if 0 <= self.position.x + direction[0] < config.row_length and 0 <= self.position.y + direction[1] < config.column_length:
+            if not world[self.position.y + direction[1]][self.position.x + direction[0]].has_organism:
+                self.position.x += direction[0]
+                self.position.y += direction[1]
 
     def update_lifetime(self):
         self.lifetime -= 100 / self.vitality
         if self.lifetime <= 0:
             self.alive = False
     
-    def update(self, config, grid):
-        grid[self.position.y][self.position.x].has_organism = False
-        self.move(self.directions[self.nn.calc_greatest(self.eyes.sight(config, grid, self.position.x, self.position.y))], config)
-        grid[self.position.y][self.position.x].has_organism = True
-        if grid[self.position.y][self.position.x].content == "food":
-            self.eat(config, grid)
+    def update(self, config, world):
+        world[self.position.y][self.position.x].has_organism = False
+        self.move(config, self.directions[self.nn.calc_greatest(self.eyes.sight(config, world, self.position.x, self.position.y))], world)
+        world[self.position.y][self.position.x].has_organism = True
+        if world[self.position.y][self.position.x].content == "food":
+            self.eat(config, world)
         # self.update_lifetime()
 
 

--- a/src/organisms/population.py
+++ b/src/organisms/population.py
@@ -3,7 +3,13 @@ from random import randint
 
 class Population:
     def __init__(self, config):
-        self.organisms = [Organism(config, randint(0, config.row_length - 1), randint(0, config.column_length - 1)) for i in range(config.population_size)]
+        self.organisms = []
+        self.organism_coords = []
+        while len(self.organisms) < config.population_size:
+            coords = (randint(0, config.row_length - 1), randint(0, config.column_length - 1))
+            if coords not in self.organism_coords:
+                self.organisms.append(Organism(config, coords[0], coords[1]))
+                self.organism_coords.append(coords)
     
     def draw(self, config, display):
         for organism in self.organisms:


### PR DESCRIPTION
- organisms check the tile they want to move to, if it's out of bounds or if there is another organism on it, the organism won't move to it.
- when spawning in organisms they check a list with coordinates of all other organisms that are already spawned and won't spawn until they found an "empty" tile
- spawning this way may take a very long time, if the number of organisms gets close to the total number of tiles in the world, or can entirely break if it exceeds the number of tiles